### PR TITLE
feat: Improve 'fn' snippet tab stops and empty body

### DIFF
--- a/snippets/snippets.code-snippets
+++ b/snippets/snippets.code-snippets
@@ -219,8 +219,8 @@
     "fn": {
         "prefix": "fn",
         "body": [
-            "fn ${1:name}($0) -> i32 {",
-            "\t1",
+            "fn ${1:name}(${2}) -> ${3:i32} {",
+            "\t$4",
             "}"
         ],
         "description": "fn decl"


### PR DESCRIPTION
The previous 'fn' snippet had a less intuitive tab order and a pre-filled body (1).

This PR reconfigures the tab stops to provide a smoother workflow:

1. function name
2. parameters
3. return type
4. empty function body.

It also changes the default body to be empty, making it ready for user input directly.